### PR TITLE
Add surgeries model, migration, factory and seeder

### DIFF
--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Surgery extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'patient_name',
+        'surgery_type',
+        'room',
+        'starts_at',
+        'duration_min',
+        'ends_at',
+        'status',
+        'is_conflict',
+        'created_by',
+        'confirmed_by',
+        'canceled_by',
+    ];
+
+    protected $casts = [
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+        'is_conflict' => 'boolean',
+        'duration_min' => 'integer',
+    ];
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function confirmedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'confirmed_by');
+    }
+
+    public function canceledBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'canceled_by');
+    }
+}

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Surgery;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends Factory<\App\Models\Surgery>
+ */
+class SurgeryFactory extends Factory
+{
+    protected $model = Surgery::class;
+
+    public function definition(): array
+    {
+        $starts = Carbon::instance($this->faker->dateTimeBetween('-1 week', '+1 week'));
+        $duration = $this->faker->numberBetween(30, 180);
+        $ends = (clone $starts)->addMinutes($duration);
+
+        return [
+            'patient_name' => $this->faker->name(),
+            'surgery_type' => $this->faker->word(),
+            'room' => $this->faker->randomElement(['A', 'B', 'C']),
+            'starts_at' => $starts,
+            'duration_min' => $duration,
+            'ends_at' => $ends,
+            'status' => 'scheduled',
+            'is_conflict' => false,
+            'created_by' => User::factory(),
+            'confirmed_by' => null,
+            'canceled_by' => null,
+        ];
+    }
+}

--- a/database/migrations/2025_09_10_172300_create_surgeries_table.php
+++ b/database/migrations/2025_09_10_172300_create_surgeries_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('surgeries', function (Blueprint $table) {
+            $table->id();
+            $table->string('patient_name');
+            $table->string('surgery_type')->nullable();
+            $table->string('room')->nullable();
+            $table->dateTime('starts_at');
+            $table->unsignedInteger('duration_min');
+            $table->dateTime('ends_at');
+            $table->string('status')->default('scheduled');
+            $table->boolean('is_conflict')->default(false);
+            $table->foreignId('created_by')->constrained('users');
+            $table->foreignId('confirmed_by')->nullable()->constrained('users');
+            $table->foreignId('canceled_by')->nullable()->constrained('users');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('surgeries');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,5 +18,7 @@ class DatabaseSeeder extends Seeder
         //     'name' => 'Test User',
         //     'email' => 'test@example.com',
         // ]);
+
+        $this->call(SurgerySeeder::class);
     }
 }

--- a/database/seeders/SurgerySeeder.php
+++ b/database/seeders/SurgerySeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Surgery;
+use Illuminate\Database\Seeder;
+
+class SurgerySeeder extends Seeder
+{
+    public function run(): void
+    {
+        Surgery::factory()->count(10)->create();
+    }
+}


### PR DESCRIPTION
## Summary
- add surgeries table migration with scheduling fields and user references
- introduce `Surgery` model with fillables, casts and relationships
- provide factory and seeder for generating sample surgeries

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0, current 8.4.12)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b3aef2b4832a96e239e395508712