### PR TITLE
Add surgery management endpoints with role-based access

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Surgery;
+use Illuminate\Http\Request;
+
+class SurgeryController extends Controller
+{
+    public function index(Request $request)
+    {
+        $user = $request->user();
+        $query = Surgery::query();
+
+        if ($user->hasRole('doctor')) {
+            $query->where('doctor_id', $user->id);
+        }
+
+        $surgeries = $query->orderBy('starts_at')
+            ->paginate($request->integer('per_page', 15));
+
+        return response()->json($surgeries);
+    }
+
+    public function store(Request $request)
+    {
+        $user = $request->user();
+        abort_unless($user->hasRole('admin') || $user->hasRole('doctor'), 403);
+
+        $data = $request->validate([
+            'patient_name' => 'required|string',
+            'starts_at' => 'required|date',
+            'ends_at' => 'nullable|date|after_or_equal:starts_at',
+            'doctor_id' => 'sometimes|exists:users,id',
+        ]);
+
+        if ($user->hasRole('doctor')) {
+            $data['doctor_id'] = $user->id;
+        }
+
+        $surgery = Surgery::create($data);
+
+        return response()->json($surgery, 201);
+    }
+
+    public function update(Request $request, Surgery $surgery)
+    {
+        $user = $request->user();
+        abort_unless(
+            $user->hasRole('admin') ||
+                ($user->hasRole('doctor') && $surgery->doctor_id === $user->id),
+            403
+        );
+
+        $data = $request->validate([
+            'patient_name' => 'sometimes|string',
+            'starts_at' => 'sometimes|date',
+            'ends_at' => 'nullable|date|after_or_equal:starts_at',
+            'doctor_id' => 'sometimes|exists:users,id',
+            'status' => 'sometimes|string',
+        ]);
+
+        if ($user->hasRole('doctor')) {
+            unset($data['doctor_id']);
+        }
+
+        $surgery->update($data);
+
+        return response()->json($surgery);
+    }
+
+    public function destroy(Request $request, Surgery $surgery)
+    {
+        $user = $request->user();
+        abort_unless(
+            $user->hasRole('admin') ||
+                ($user->hasRole('doctor') && $surgery->doctor_id === $user->id),
+            403
+        );
+
+        $surgery->delete();
+
+        return response()->noContent();
+    }
+
+    public function confirm(Request $request, Surgery $surgery)
+    {
+        $user = $request->user();
+        abort_unless($user->hasRole('admin') || $user->hasRole('nurse'), 403);
+
+        $surgery->update(['status' => Surgery::STATUS_CONFIRMED]);
+
+        return response()->json($surgery);
+    }
+
+    public function cancel(Request $request, Surgery $surgery)
+    {
+        $user = $request->user();
+        abort_unless($user->hasRole('admin') || $user->hasRole('nurse'), 403);
+
+        $surgery->update(['status' => Surgery::STATUS_CANCELLED]);
+
+        return response()->json($surgery);
+    }
+}

--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Surgery extends Model
+{
+    use HasFactory;
+
+    public const STATUS_SCHEDULED = 'scheduled';
+    public const STATUS_CONFIRMED = 'confirmed';
+    public const STATUS_CANCELLED = 'cancelled';
+
+    protected $fillable = [
+        'doctor_id',
+        'patient_name',
+        'starts_at',
+        'ends_at',
+        'status',
+    ];
+
+    protected $casts = [
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+    ];
+
+    public function doctor()
+    {
+        return $this->belongsTo(User::class, 'doctor_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,10 +7,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Surgery;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Surgery>
+ */
+class SurgeryFactory extends Factory
+{
+    protected $model = Surgery::class;
+
+    public function definition(): array
+    {
+        return [
+            'doctor_id' => User::factory(),
+            'patient_name' => $this->faker->name(),
+            'starts_at' => $this->faker->dateTimeBetween('+1 days', '+1 month'),
+            'ends_at' => $this->faker->dateTimeBetween('+1 month', '+2 months'),
+            'status' => Surgery::STATUS_SCHEDULED,
+        ];
+    }
+}

--- a/database/migrations/2025_09_10_170923_create_surgeries_table.php
+++ b/database/migrations/2025_09_10_170923_create_surgeries_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('surgeries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('doctor_id')->constrained('users');
+            $table->string('patient_name');
+            $table->timestamp('starts_at');
+            $table->timestamp('ends_at')->nullable();
+            $table->string('status')->default('scheduled');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('surgeries');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\SurgeryController;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,4 +17,10 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
+});
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::apiResource('surgeries', SurgeryController::class)->except(['show']);
+    Route::post('surgeries/{surgery}/confirm', [SurgeryController::class, 'confirm']);
+    Route::post('surgeries/{surgery}/cancel', [SurgeryController::class, 'cancel']);
 });


### PR DESCRIPTION
## Summary
- add Surgery model, migration and factory
- implement SurgeryController with CRUD, confirm, cancel and paginated listing
- register authenticated surgery routes and enable user roles via spatie

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0 -> your php version (8.4.12) does not satisfy that requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b3b089e0832a97aa849feef9589e