### PR TITLE
feat: add surgery scheduling and management

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Surgery;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class SurgeryController extends Controller
+{
+    public function store(Request $request)
+    {
+        if (Auth::user()->hasRole('nurse')) {
+            abort(403, 'Nurses cannot modify basic surgery data.');
+        }
+
+        $data = $request->validate([
+            'room_id' => ['required', 'integer'],
+            'starts_at' => ['required', 'date'],
+            'duration_min' => ['required', 'integer', 'min:1'],
+        ]);
+
+        $surgery = Surgery::create($data);
+
+        return response()->json($surgery, 201);
+    }
+
+    public function update(Request $request, Surgery $surgery)
+    {
+        if (Auth::user()->hasRole('nurse')) {
+            abort(403, 'Nurses cannot modify basic surgery data.');
+        }
+
+        $data = $request->validate([
+            'room_id' => ['sometimes', 'integer'],
+            'starts_at' => ['sometimes', 'date'],
+            'duration_min' => ['sometimes', 'integer', 'min:1'],
+        ]);
+
+        $surgery->update($data);
+
+        return response()->json($surgery);
+    }
+
+    public function confirm(Surgery $surgery)
+    {
+        if (Auth::user()->hasRole('doctor')) {
+            abort(403, 'Doctors cannot confirm surgeries.');
+        }
+
+        $surgery->update([
+            'status' => 'confirmed',
+            'confirmed_by' => Auth::id(),
+            'canceled_by' => null,
+        ]);
+
+        return response()->json($surgery);
+    }
+
+    public function cancel(Surgery $surgery)
+    {
+        if (Auth::user()->hasRole('doctor')) {
+            abort(403, 'Doctors cannot cancel surgeries.');
+        }
+
+        $surgery->update([
+            'status' => 'canceled',
+            'canceled_by' => Auth::id(),
+            'confirmed_by' => null,
+        ]);
+
+        return response()->json($surgery);
+    }
+}

--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Surgery extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'room_id',
+        'starts_at',
+        'duration_min',
+        'ends_at',
+        'is_conflict',
+        'status',
+        'confirmed_by',
+        'canceled_by',
+    ];
+
+    protected $casts = [
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+        'is_conflict' => 'boolean',
+    ];
+
+    protected static function booted()
+    {
+        static::saving(function (Surgery $surgery) {
+            if ($surgery->starts_at && $surgery->duration_min) {
+                $surgery->ends_at = $surgery->starts_at->copy()->addMinutes($surgery->duration_min);
+            }
+
+            if ($surgery->starts_at && $surgery->ends_at && $surgery->room_id) {
+                $query = static::where('room_id', $surgery->room_id)
+                    ->where('id', '!=', $surgery->id)
+                    ->where(function ($q) use ($surgery) {
+                        $q->whereBetween('starts_at', [$surgery->starts_at, $surgery->ends_at])
+                          ->orWhereBetween('ends_at', [$surgery->starts_at, $surgery->ends_at])
+                          ->orWhere(function ($q2) use ($surgery) {
+                              $q2->where('starts_at', '<', $surgery->starts_at)
+                                 ->where('ends_at', '>', $surgery->ends_at);
+                          });
+                    });
+                $surgery->is_conflict = $query->exists();
+            }
+        });
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,10 +7,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Surgery;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends Factory<Surgery>
+ */
+class SurgeryFactory extends Factory
+{
+    protected $model = Surgery::class;
+
+    public function definition(): array
+    {
+        $start = $this->faker->dateTimeBetween('+0 days', '+1 week');
+
+        return [
+            'room_id' => $this->faker->numberBetween(1, 5),
+            'starts_at' => $start,
+            'duration_min' => $this->faker->numberBetween(30, 240),
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_000000_create_surgeries_table.php
+++ b/database/migrations/2024_01_01_000000_create_surgeries_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('surgeries', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('room_id');
+            $table->timestamp('starts_at');
+            $table->integer('duration_min');
+            $table->timestamp('ends_at')->nullable();
+            $table->boolean('is_conflict')->default(false);
+            $table->string('status')->default('scheduled');
+            $table->foreignId('confirmed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('canceled_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('surgeries');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,3 +17,9 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::apiResource('surgeries', \App\Http\Controllers\SurgeryController::class);
+    Route::post('surgeries/{surgery}/confirm', [\App\Http\Controllers\SurgeryController::class, 'confirm']);
+    Route::post('surgeries/{surgery}/cancel', [\App\Http\Controllers\SurgeryController::class, 'cancel']);
+});


### PR DESCRIPTION
## Summary
- add surgeries table and model with conflict detection
- implement surgery controller with confirmation and cancellation flow
- secure actions with role checks and expose surgery API routes

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: inertiajs/inertia-laravel requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b3b1a0f8832a98ca67b2f4630a75