### PR TITLE
Add admin-configurable max rooms and surgery validation

### DIFF
--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Setting;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class SettingController extends Controller
+{
+    public function edit()
+    {
+        $maxRooms = (int) Setting::getValue('max_rooms', 1);
+
+        return Inertia::render('Settings/Edit', [
+            'maxRooms' => $maxRooms,
+        ]);
+    }
+
+    public function update(Request $request)
+    {
+        $data = $request->validate([
+            'maxRooms' => ['required', 'integer', 'min:1'],
+        ]);
+
+        Setting::setValue('max_rooms', $data['maxRooms']);
+
+        return redirect()->route('settings.edit');
+    }
+}

--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Setting;
+use App\Models\Surgery;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class SurgeryController extends Controller
+{
+    public function create()
+    {
+        $maxRooms = (int) Setting::getValue('max_rooms', 1);
+
+        return Inertia::render('Surgeries/Create', [
+            'maxRooms' => $maxRooms,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $maxRooms = (int) Setting::getValue('max_rooms', 1);
+
+        $data = $request->validate([
+            'room' => ['required', 'integer', 'min:1', 'max:' . $maxRooms],
+        ]);
+
+        Surgery::create($data);
+
+        return redirect()->route('surgeries.create');
+    }
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    protected $fillable = ['key', 'value'];
+
+    public static function getValue(string $key, $default = null)
+    {
+        return static::where('key', $key)->value('value') ?? $default;
+    }
+
+    public static function setValue(string $key, $value): void
+    {
+        static::updateOrCreate(['key' => $key], ['value' => $value]);
+    }
+}

--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Surgery extends Model
+{
+    protected $fillable = ['room'];
+}

--- a/database/migrations/2024_05_06_000000_create_settings_table.php
+++ b/database/migrations/2024_05_06_000000_create_settings_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('value');
+            $table->timestamps();
+        });
+
+        DB::table('settings')->insert([
+            'key' => 'max_rooms',
+            'value' => '1',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/migrations/2024_05_06_000100_create_surgeries_table.php
+++ b/database/migrations/2024_05_06_000100_create_surgeries_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('surgeries', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('room');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('surgeries');
+    }
+};

--- a/resources/js/Pages/Settings/Edit.vue
+++ b/resources/js/Pages/Settings/Edit.vue
@@ -1,0 +1,27 @@
+<script setup>
+import { useForm } from '@inertiajs/vue3';
+
+const props = defineProps({
+    maxRooms: Number,
+});
+
+const form = useForm({
+    maxRooms: props.maxRooms,
+});
+</script>
+
+<template>
+    <div>
+        <h1 class="text-xl font-bold">Settings</h1>
+        <form @submit.prevent="form.post(route('settings.update'))" class="mt-4">
+            <div>
+                <label for="maxRooms" class="block font-medium">Max Rooms</label>
+                <input id="maxRooms" type="number" min="1" v-model="form.maxRooms" class="mt-1 border rounded w-full" />
+                <div v-if="form.errors.maxRooms" class="text-red-500 text-sm mt-1">{{ form.errors.maxRooms }}</div>
+            </div>
+            <button type="submit" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded" :disabled="form.processing">
+                Save
+            </button>
+        </form>
+    </div>
+</template>

--- a/resources/js/Pages/Surgeries/Create.vue
+++ b/resources/js/Pages/Surgeries/Create.vue
@@ -1,0 +1,27 @@
+<script setup>
+import { useForm } from '@inertiajs/vue3';
+
+const props = defineProps({
+    maxRooms: Number,
+});
+
+const form = useForm({
+    room: '',
+});
+</script>
+
+<template>
+    <div>
+        <h1 class="text-xl font-bold">Create Surgery</h1>
+        <form @submit.prevent="form.post(route('surgeries.store'))" class="mt-4">
+            <div>
+                <label for="room" class="block font-medium">Room (1 - {{ maxRooms }})</label>
+                <input id="room" type="number" min="1" :max="maxRooms" v-model="form.room" class="mt-1 border rounded w-full" />
+                <div v-if="form.errors.room" class="text-red-500 text-sm mt-1">{{ form.errors.room }}</div>
+            </div>
+            <button type="submit" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded" :disabled="form.processing">
+                Save
+            </button>
+        </form>
+    </div>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\SettingController;
+use App\Http\Controllers\SurgeryController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -33,6 +35,12 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::get('/settings', [SettingController::class, 'edit'])->name('settings.edit');
+    Route::post('/settings', [SettingController::class, 'update'])->name('settings.update');
+
+    Route::get('/surgeries/create', [SurgeryController::class, 'create'])->name('surgeries.create');
+    Route::post('/surgeries', [SurgeryController::class, 'store'])->name('surgeries.store');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add settings table with default max_rooms and model accessors
- build admin interface to update max rooms
- inject maxRooms into surgery form and enforce 1..maxRooms validation

## Testing
- `npm test` (fails: Missing script "test")
- `vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68c1b3b31490832a97e4797d91475c36