### PR TITLE
Add surgery details and conflict logic

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -30,7 +30,9 @@ class SurgeryController extends Controller
         $data = $request->validate([
             'patient_name' => 'required|string',
             'starts_at' => 'required|date',
-            'ends_at' => 'nullable|date|after_or_equal:starts_at',
+            'duration_min' => 'required|integer|min:1',
+            'surgery_type' => 'required|string',
+            'room' => 'required|string',
             'doctor_id' => 'sometimes|exists:users,id',
         ]);
 
@@ -55,7 +57,9 @@ class SurgeryController extends Controller
         $data = $request->validate([
             'patient_name' => 'sometimes|string',
             'starts_at' => 'sometimes|date',
-            'ends_at' => 'nullable|date|after_or_equal:starts_at',
+            'duration_min' => 'sometimes|integer|min:1',
+            'surgery_type' => 'sometimes|string',
+            'room' => 'sometimes|string',
             'doctor_id' => 'sometimes|exists:users,id',
             'status' => 'sometimes|string',
         ]);
@@ -88,7 +92,10 @@ class SurgeryController extends Controller
         $user = $request->user();
         abort_unless($user->hasRole('admin') || $user->hasRole('nurse'), 403);
 
-        $surgery->update(['status' => Surgery::STATUS_CONFIRMED]);
+        $surgery->update([
+            'status' => Surgery::STATUS_CONFIRMED,
+            'confirmed_by' => $user->id,
+        ]);
 
         return response()->json($surgery);
     }
@@ -98,7 +105,10 @@ class SurgeryController extends Controller
         $user = $request->user();
         abort_unless($user->hasRole('admin') || $user->hasRole('nurse'), 403);
 
-        $surgery->update(['status' => Surgery::STATUS_CANCELLED]);
+        $surgery->update([
+            'status' => Surgery::STATUS_CANCELLED,
+            'canceled_by' => $user->id,
+        ]);
 
         return response()->json($surgery);
     }

--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Carbon\Carbon;
 
 class Surgery extends Model
 {
@@ -19,15 +20,73 @@ class Surgery extends Model
         'starts_at',
         'ends_at',
         'status',
+        'surgery_type',
+        'room',
+        'duration_min',
+        'is_conflict',
+        'confirmed_by',
+        'canceled_by',
     ];
 
     protected $casts = [
         'starts_at' => 'datetime',
         'ends_at' => 'datetime',
+        'duration_min' => 'integer',
+        'is_conflict' => 'boolean',
     ];
 
     public function doctor()
     {
         return $this->belongsTo(User::class, 'doctor_id');
+    }
+
+    public function confirmedBy()
+    {
+        return $this->belongsTo(User::class, 'confirmed_by');
+    }
+
+    public function canceledBy()
+    {
+        return $this->belongsTo(User::class, 'canceled_by');
+    }
+
+    protected static function booted()
+    {
+        static::saving(function (self $surgery) {
+            if ($surgery->starts_at instanceof Carbon && $surgery->duration_min) {
+                $surgery->ends_at = $surgery->starts_at->copy()->addMinutes($surgery->duration_min);
+            }
+
+            if ($surgery->doctor_id && $surgery->starts_at && $surgery->duration_min) {
+                $surgery->is_conflict = self::hasConflict(
+                    $surgery->doctor_id,
+                    $surgery->starts_at,
+                    $surgery->duration_min,
+                    $surgery->id
+                );
+            }
+        });
+    }
+
+    public static function hasConflict(int $doctorId, $startsAt, int $durationMin, ?int $ignoreId = null): bool
+    {
+        $starts = Carbon::parse($startsAt);
+        $ends = $starts->copy()->addMinutes($durationMin);
+
+        $query = static::where('doctor_id', $doctorId)
+            ->where(function ($q) use ($starts, $ends) {
+                $q->whereBetween('starts_at', [$starts, $ends])
+                    ->orWhereBetween('ends_at', [$starts, $ends])
+                    ->orWhere(function ($q2) use ($starts, $ends) {
+                        $q2->where('starts_at', '<', $starts)
+                            ->where('ends_at', '>', $ends);
+                    });
+            });
+
+        if ($ignoreId) {
+            $query->where('id', '!=', $ignoreId);
+        }
+
+        return $query->exists();
     }
 }

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -19,7 +19,9 @@ class SurgeryFactory extends Factory
             'doctor_id' => User::factory(),
             'patient_name' => $this->faker->name(),
             'starts_at' => $this->faker->dateTimeBetween('+1 days', '+1 month'),
-            'ends_at' => $this->faker->dateTimeBetween('+1 month', '+2 months'),
+            'duration_min' => $this->faker->numberBetween(30, 240),
+            'surgery_type' => $this->faker->word(),
+            'room' => (string) $this->faker->numberBetween(1, 10),
             'status' => Surgery::STATUS_SCHEDULED,
         ];
     }

--- a/database/migrations/2025_09_10_170931_add_missing_fields_to_surgeries_table.php
+++ b/database/migrations/2025_09_10_170931_add_missing_fields_to_surgeries_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('surgeries', function (Blueprint $table) {
+            $table->string('surgery_type')->nullable();
+            $table->string('room')->nullable();
+            $table->unsignedInteger('duration_min')->nullable();
+            $table->boolean('is_conflict')->default(false);
+            $table->foreignId('confirmed_by')->nullable()->constrained('users');
+            $table->foreignId('canceled_by')->nullable()->constrained('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('surgeries', function (Blueprint $table) {
+            $table->dropColumn(['surgery_type', 'room', 'duration_min', 'is_conflict']);
+            $table->dropConstrainedForeignId('confirmed_by');
+            $table->dropConstrainedForeignId('canceled_by');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add migration to expand surgeries fields
- update Surgery model with new attributes, relationships, conflict detection, and automatic end time
- extend Surgery controller and factory for new data and tracking

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --ignore-platform-reqs` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b9d69b24832a8a7e2a182bd59f9e