### PR TITLE
feat: handle surgery conflicts and confirmations

### DIFF
--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -16,18 +16,39 @@ class Surgery extends Model
     protected $fillable = [
         'doctor_id',
         'patient_name',
+        'room',
         'starts_at',
         'ends_at',
         'status',
+        'is_conflict',
+        'created_by',
+        'confirmed_by',
+        'canceled_by',
     ];
 
     protected $casts = [
         'starts_at' => 'datetime',
         'ends_at' => 'datetime',
+        'is_conflict' => 'boolean',
     ];
 
     public function doctor()
     {
         return $this->belongsTo(User::class, 'doctor_id');
+    }
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function confirmedBy()
+    {
+        return $this->belongsTo(User::class, 'confirmed_by');
+    }
+
+    public function canceledBy()
+    {
+        return $this->belongsTo(User::class, 'canceled_by');
     }
 }

--- a/database/migrations/2025_09_10_170923_create_surgeries_table.php
+++ b/database/migrations/2025_09_10_170923_create_surgeries_table.php
@@ -14,9 +14,14 @@ return new class extends Migration {
             $table->id();
             $table->foreignId('doctor_id')->constrained('users');
             $table->string('patient_name');
+            $table->unsignedInteger('room');
             $table->timestamp('starts_at');
             $table->timestamp('ends_at')->nullable();
+            $table->boolean('is_conflict')->default(false);
             $table->string('status')->default('scheduled');
+            $table->foreignId('created_by')->constrained('users');
+            $table->foreignId('confirmed_by')->nullable()->constrained('users');
+            $table->foreignId('canceled_by')->nullable()->constrained('users');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
## Summary
- flag time conflicts on surgery store/update
- track creator, confirmation, and cancelation details
- restrict editing, confirmation, and cancelation actions by role

## Testing
- `php artisan test` *(fails: require vendor/autoload.php: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68c1b9db8b00832a8dcf290f0be76cac