### PR TITLE
Add configurable max surgery rooms setting

### DIFF
--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Setting;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class SettingController extends Controller
+{
+    public function edit(Request $request)
+    {
+        abort_unless($request->user()?->isAdmin(), 403);
+
+        return Inertia::render('Settings/Index', [
+            'maxRooms' => (int) Setting::getValue('max_rooms', 9),
+        ]);
+    }
+
+    public function update(Request $request)
+    {
+        $user = $request->user();
+        abort_unless($user?->isAdmin(), 403);
+
+        $data = $request->validate([
+            'max_rooms' => 'required|integer|min:1',
+        ]);
+
+        Setting::setValue('max_rooms', (string) $data['max_rooms']);
+
+        return redirect()->back();
+    }
+}

--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Surgery;
+use App\Models\Setting;
 use Illuminate\Http\Request;
 
 class SurgeryController extends Controller
@@ -10,6 +11,7 @@ class SurgeryController extends Controller
     public function index(Request $request)
     {
         $user = $request->user();
+        $maxRooms = (int) Setting::getValue('max_rooms', 9);
         $query = Surgery::query();
 
         if ($user->hasRole('doctor')) {
@@ -19,6 +21,11 @@ class SurgeryController extends Controller
         $surgeries = $query->orderBy('starts_at')
             ->paginate($request->integer('per_page', 15));
 
+        $surgeries->getCollection()->transform(function ($surgery) use ($maxRooms) {
+            $surgery->is_conflict = $this->hasConflict($surgery, $maxRooms);
+            return $surgery;
+        });
+
         return response()->json($surgeries);
     }
 
@@ -27,11 +34,13 @@ class SurgeryController extends Controller
         $user = $request->user();
         abort_unless($user->hasRole('admin') || $user->hasRole('doctor'), 403);
 
+        $maxRooms = (int) Setting::getValue('max_rooms', 9);
         $data = $request->validate([
             'patient_name' => 'required|string',
             'starts_at' => 'required|date',
             'ends_at' => 'nullable|date|after_or_equal:starts_at',
             'doctor_id' => 'sometimes|exists:users,id',
+            'room' => 'required|integer|min:1|max:' . $maxRooms,
         ]);
 
         if ($user->hasRole('doctor')) {
@@ -39,6 +48,7 @@ class SurgeryController extends Controller
         }
 
         $surgery = Surgery::create($data);
+        $surgery->is_conflict = $this->hasConflict($surgery, $maxRooms);
 
         return response()->json($surgery, 201);
     }
@@ -52,12 +62,14 @@ class SurgeryController extends Controller
             403
         );
 
+        $maxRooms = (int) Setting::getValue('max_rooms', 9);
         $data = $request->validate([
             'patient_name' => 'sometimes|string',
             'starts_at' => 'sometimes|date',
             'ends_at' => 'nullable|date|after_or_equal:starts_at',
             'doctor_id' => 'sometimes|exists:users,id',
             'status' => 'sometimes|string',
+            'room' => 'sometimes|integer|min:1|max:' . $maxRooms,
         ]);
 
         if ($user->hasRole('doctor')) {
@@ -65,6 +77,7 @@ class SurgeryController extends Controller
         }
 
         $surgery->update($data);
+        $surgery->is_conflict = $this->hasConflict($surgery, $maxRooms);
 
         return response()->json($surgery);
     }
@@ -101,5 +114,15 @@ class SurgeryController extends Controller
         $surgery->update(['status' => Surgery::STATUS_CANCELLED]);
 
         return response()->json($surgery);
+    }
+
+    private function hasConflict(Surgery $surgery, int $maxRooms): bool
+    {
+        $overlap = Surgery::where('id', '!=', $surgery->id)
+            ->where('starts_at', '<', $surgery->ends_at)
+            ->where('ends_at', '>', $surgery->starts_at)
+            ->count();
+
+        return $overlap >= $maxRooms;
     }
 }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    protected $fillable = ['key', 'value'];
+
+    public static function getValue(string $key, $default = null)
+    {
+        return static::query()->where('key', $key)->value('value') ?? $default;
+    }
+
+    public static function setValue(string $key, $value): self
+    {
+        return static::updateOrCreate(['key' => $key], ['value' => $value]);
+    }
+}

--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -16,6 +16,7 @@ class Surgery extends Model
     protected $fillable = [
         'doctor_id',
         'patient_name',
+        'room',
         'starts_at',
         'ends_at',
         'status',

--- a/database/migrations/2025_09_10_170931_create_settings_table.php
+++ b/database/migrations/2025_09_10_170931_create_settings_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('value');
+            $table->timestamps();
+        });
+
+        DB::table('settings')->insert([
+            'key' => 'max_rooms',
+            'value' => '9',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/migrations/2025_09_10_170932_add_room_to_surgeries_table.php
+++ b/database/migrations/2025_09_10_170932_add_room_to_surgeries_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('surgeries', function (Blueprint $table) {
+            $table->unsignedInteger('room')->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('surgeries', function (Blueprint $table) {
+            $table->dropColumn('room');
+        });
+    }
+};

--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -1,0 +1,44 @@
+<script setup>
+import { ref } from 'vue';
+import { Head, router } from '@inertiajs/vue3';
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import TextInput from '@/Components/TextInput.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+
+const props = defineProps({
+    maxRooms: Number,
+});
+
+const form = ref({
+    max_rooms: props.maxRooms || 1,
+});
+
+const submit = () => {
+    router.post('/settings', form.value);
+};
+</script>
+
+<template>
+    <Head title="Configurações" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Configurações</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                    <form @submit.prevent="submit" class="space-y-4">
+                        <div>
+                            <InputLabel for="max_rooms" value="Número máximo de salas" />
+                            <TextInput id="max_rooms" type="number" v-model="form.max_rooms" class="mt-1 block w-full" />
+                        </div>
+                        <PrimaryButton type="submit">Salvar</PrimaryButton>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\SettingController;
+use App\Models\Setting;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -33,6 +35,18 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::get('/settings', [SettingController::class, 'edit'])->name('settings.edit');
+    Route::post('/settings', [SettingController::class, 'update'])->name('settings.update');
+
+    Route::get('/surgeries', function () {
+        return Inertia::render('Surgeries/Index', [
+            'surgeries' => [],
+            'patients' => [],
+            'types' => [],
+            'rooms' => (int) Setting::getValue('max_rooms', 9),
+        ]);
+    })->name('surgeries.index');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add settings table/model with default `max_rooms`
- expose admin UI and routes to edit `max_rooms`
- validate surgery room against setting and flag conflicts

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: Failed to open required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c1b9de368c832aa0adc9806ae7b193