### PR TITLE
Add nurse role support and seeding

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,6 +16,7 @@ class User extends Authenticatable
     public const ROLE_PATIENT = 'patient';
     public const ROLE_DOCTOR = 'doctor';
     public const ROLE_ADMIN = 'admin';
+    public const ROLE_NURSE = 'nurse';
 
     /**
      * The attributes that are mass assignable.
@@ -63,5 +64,10 @@ class User extends Authenticatable
     public function isAdmin(): bool
     {
         return $this->role === self::ROLE_ADMIN;
+    }
+
+    public function isNurse(): bool
+    {
+        return $this->hasRole(self::ROLE_NURSE);
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -34,6 +34,13 @@ class UserFactory extends Factory
         ];
     }
 
+    public function nurse(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'role' => User::ROLE_NURSE,
+        ]);
+    }
+
     /**
      * Indicate that the model's email address should be unverified.
      */

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use App\Models\User;
+use Spatie\Permission\Models\Role;
 
 class DatabaseSeeder extends Seeder
 {
@@ -13,6 +14,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        Role::firstOrCreate(['name' => User::ROLE_NURSE]);
+
         User::factory()->create([
             'name' => 'Admin User',
             'email' => 'admin@example.com',
@@ -30,5 +33,11 @@ class DatabaseSeeder extends Seeder
             'email' => 'patient@example.com',
             'role' => User::ROLE_PATIENT,
         ]);
+
+        User::factory()->create([
+            'name' => 'Nurse User',
+            'email' => 'nurse@example.com',
+            'role' => User::ROLE_NURSE,
+        ])->assignRole(User::ROLE_NURSE);
     }
 }


### PR DESCRIPTION
## Summary
- define nurse role constant and helper on User model
- allow UserFactory to create nurses
- seed a nurse user with appropriate role assignment

## Testing
- ⚠️ `php artisan migrate --seed` *(failed: vendor/autoload.php missing due to composer install failing with GitHub 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c8162f888c832a86768d19ab157e1b