### PR TITLE
Use Spatie roles for authorization

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -44,6 +44,8 @@ class RegisteredUserController extends Controller
             'role' => User::ROLE_PATIENT,
         ]);
 
+        $user->assignRole(User::ROLE_PATIENT);
+
         event(new Registered($user));
 
         Auth::login($user);

--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Setting;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 
@@ -10,7 +11,7 @@ class SettingController extends Controller
 {
     public function edit(Request $request)
     {
-        abort_unless($request->user()?->isAdmin(), 403);
+        abort_unless($request->user()?->hasRole(User::ROLE_ADMIN), 403);
 
         return Inertia::render('Settings/Index', [
             'maxRooms' => (int) Setting::getValue('max_rooms', 9),
@@ -20,7 +21,7 @@ class SettingController extends Controller
     public function update(Request $request)
     {
         $user = $request->user();
-        abort_unless($user?->isAdmin(), 403);
+        abort_unless($user?->hasRole(User::ROLE_ADMIN), 403);
 
         $data = $request->validate([
             'max_rooms' => 'required|integer|min:1',

--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Surgery;
 use App\Models\Setting;
+use App\Models\User;
 use Illuminate\Http\Request;
 
 class SurgeryController extends Controller
@@ -14,7 +15,7 @@ class SurgeryController extends Controller
         $maxRooms = (int) Setting::getValue('max_rooms', 9);
         $query = Surgery::query();
 
-        if ($user->hasRole('doctor')) {
+        if ($user->hasRole(User::ROLE_DOCTOR)) {
             $query->where('doctor_id', $user->id);
         }
 
@@ -32,7 +33,7 @@ class SurgeryController extends Controller
     public function store(Request $request)
     {
         $user = $request->user();
-        abort_unless($user->hasRole('admin') || $user->hasRole('doctor'), 403);
+        abort_unless($user->hasRole(User::ROLE_ADMIN) || $user->hasRole(User::ROLE_DOCTOR), 403);
 
         $maxRooms = (int) Setting::getValue('max_rooms', 9);
         $data = $request->validate([
@@ -44,7 +45,7 @@ class SurgeryController extends Controller
             'room' => 'required|integer|min:1|max:' . $maxRooms,
         ]);
 
-        if ($user->hasRole('doctor')) {
+        if ($user->hasRole(User::ROLE_DOCTOR)) {
             $data['doctor_id'] = $user->id;
         }
 
@@ -58,8 +59,8 @@ class SurgeryController extends Controller
     {
         $user = $request->user();
         abort_unless(
-            $user->hasRole('admin') ||
-                ($user->hasRole('doctor') && $surgery->doctor_id === $user->id),
+            $user->hasRole(User::ROLE_ADMIN) ||
+                ($user->hasRole(User::ROLE_DOCTOR) && $surgery->doctor_id === $user->id),
             403
         );
 
@@ -74,7 +75,7 @@ class SurgeryController extends Controller
             'room' => 'required|integer|min:1|max:' . $maxRooms,
         ]);
 
-        if ($user->hasRole('doctor')) {
+        if ($user->hasRole(User::ROLE_DOCTOR)) {
             unset($data['doctor_id']);
         }
 
@@ -88,8 +89,8 @@ class SurgeryController extends Controller
     {
         $user = $request->user();
         abort_unless(
-            $user->hasRole('admin') ||
-                ($user->hasRole('doctor') && $surgery->doctor_id === $user->id),
+            $user->hasRole(User::ROLE_ADMIN) ||
+                ($user->hasRole(User::ROLE_DOCTOR) && $surgery->doctor_id === $user->id),
             403
         );
 
@@ -101,7 +102,7 @@ class SurgeryController extends Controller
     public function confirm(Request $request, Surgery $surgery)
     {
         $user = $request->user();
-        abort_unless($user->hasRole('admin') || $user->hasRole('nurse'), 403);
+        abort_unless($user->hasRole(User::ROLE_ADMIN) || $user->hasRole(User::ROLE_NURSE), 403);
         abort_if($surgery->status !== Surgery::STATUS_SCHEDULED, 400);
 
         $surgery->update([
@@ -119,7 +120,7 @@ class SurgeryController extends Controller
     public function cancel(Request $request, Surgery $surgery)
     {
         $user = $request->user();
-        abort_unless($user->hasRole('admin') || $user->hasRole('nurse'), 403);
+        abort_unless($user->hasRole(User::ROLE_ADMIN) || $user->hasRole(User::ROLE_NURSE), 403);
 
         abort_if($surgery->status === Surgery::STATUS_CANCELLED, 400);
 

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -17,7 +17,7 @@ class RoleMiddleware
     public function handle(Request $request, Closure $next, ...$roles): Response
     {
         $user = Auth::user();
-        if (! $user || ($roles && ! in_array($user->role, $roles))) {
+        if (! $user || ($roles && ! $user->hasAnyRole($roles))) {
             abort(403);
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,6 +16,7 @@ class User extends Authenticatable
     public const ROLE_PATIENT = 'patient';
     public const ROLE_DOCTOR = 'doctor';
     public const ROLE_ADMIN = 'admin';
+    public const ROLE_NURSE = 'nurse';
 
     /**
      * The attributes that are mass assignable.
@@ -52,16 +53,16 @@ class User extends Authenticatable
 
     public function isDoctor(): bool
     {
-        return $this->role === self::ROLE_DOCTOR;
+        return $this->hasRole(self::ROLE_DOCTOR);
     }
 
     public function isPatient(): bool
     {
-        return $this->role === self::ROLE_PATIENT;
+        return $this->hasRole(self::ROLE_PATIENT);
     }
 
     public function isAdmin(): bool
     {
-        return $this->role === self::ROLE_ADMIN;
+        return $this->hasRole(self::ROLE_ADMIN);
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -43,4 +43,13 @@ class UserFactory extends Factory
             'email_verified_at' => null,
         ]);
     }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (User $user) {
+            if ($user->role) {
+                $user->assignRole($user->role);
+            }
+        });
+    }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use App\Models\User;
+use Spatie\Permission\Models\Role;
 
 class DatabaseSeeder extends Seeder
 {
@@ -13,6 +14,15 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        foreach ([
+            User::ROLE_ADMIN,
+            User::ROLE_DOCTOR,
+            User::ROLE_PATIENT,
+            User::ROLE_NURSE,
+        ] as $role) {
+            Role::firstOrCreate(['name' => $role]);
+        }
+
         User::factory()->create([
             'name' => 'Admin User',
             'email' => 'admin@example.com',


### PR DESCRIPTION
## Summary
- Refactor User role helpers to delegate to Spatie's `hasRole`
- Replace direct role column checks with Spatie role methods in controllers and middleware
- Seed default roles and auto-assign roles to users

## Testing
- `composer install --no-interaction --no-progress` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0 -> your php version (8.4.12) does not satisfy that requirement)*
- `php artisan test` *(fails: Failed opening required '/workspace/medico/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68c81630fa78832abdec7023b0534c44