### PR TITLE
Add settings update feature test

### DIFF
--- a/tests/Feature/SettingsUpdateTest.php
+++ b/tests/Feature/SettingsUpdateTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SettingsUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_update_max_rooms_setting(): void
+    {
+        $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+
+        $response = $this
+            ->actingAs($admin)
+            ->from('/settings')
+            ->post('/settings', [
+                'max_rooms' => 12,
+            ]);
+
+        $response->assertRedirect('/settings');
+
+        $this->assertSame('12', Setting::getValue('max_rooms'));
+    }
+}


### PR DESCRIPTION
## Summary
- add feature test ensuring admin updates to max_rooms persist via `Setting::getValue`

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68c816331b18832aa92f11e139972ebb