### PR TITLE
chore: enforce php 8.3 platform for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,9 @@
         "optimize-autoloader": true,
         "preferred-install": "dist",
         "sort-packages": true,
+        "platform": {
+            "php": "8.3"
+        },
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true


### PR DESCRIPTION
## Summary
- enforce PHP 8.3 platform in composer config to support Inertia on PHP 8.4

## Testing
- `composer update inertiajs/inertia-laravel` *(fails: curl error 56, CONNECT tunnel failed 403)*
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ~8.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c816335dd0832a9bdc09c5f88d2127